### PR TITLE
Corrige la facturación parcial de un pedido.

### DIFF
--- a/src/main/java/sic/modelo/Pedido.java
+++ b/src/main/java/sic/modelo/Pedido.java
@@ -26,8 +26,6 @@ import sic.service.EstadoPedido;
 @NamedQueries({
     @NamedQuery(name = "Pedido.buscarMayorNroPedido",
             query = "SELECT MAX(p.nroPedido) FROM Pedido p WHERE p.empresa.id_Empresa = :idEmpresa"),
-    @NamedQuery(name = "Pedido.buscarPedidoConFacturas",
-            query = "SELECT f FROM Factura f LEFT JOIN FETCH f.renglones WHERE f.eliminada = false AND f.pedido.nroPedido = :nroPedido"),
     @NamedQuery(name = "Pedido.buscarRenglonesDelPedido",
             query = "SELECT p FROM Pedido p LEFT JOIN FETCH p.renglones WHERE p.nroPedido = :nroPedido"),
     @NamedQuery(name = "Pedido.buscarPorId",

--- a/src/main/java/sic/repository/FacturaRepository.java
+++ b/src/main/java/sic/repository/FacturaRepository.java
@@ -96,7 +96,7 @@ public class FacturaRepository {
         }
         //Pedido
         if (criteria.isBuscarPorPedido() == true) {
-            query += " AND f.pedido = " + criteria.getNroPedido();
+            query += " AND f.pedido.nroPedido = " + criteria.getNroPedido();
         }
         //Inpagas
         if (criteria.isBuscaSoloInpagas() == true) {

--- a/src/main/java/sic/repository/PedidoRepository.java
+++ b/src/main/java/sic/repository/PedidoRepository.java
@@ -66,15 +66,6 @@ public class PedidoRepository {
         }
     }
 
-    public List<Factura> getFacturasDelPedido(long nroPedido) {
-        EntityManager em = PersistenceUtil.getEntityManager();
-        TypedQuery<Factura> typedQuery = em.createNamedQuery("Pedido.buscarPedidoConFacturas", Factura.class);
-        typedQuery.setParameter("nroPedido", nroPedido);
-        List<Factura> facturas = typedQuery.getResultList();
-        em.close();
-        return facturas;
-    }
-
     public void guardar(Pedido pedido) {
         EntityManager em = PersistenceUtil.getEntityManager();
         EntityTransaction tx = em.getTransaction();

--- a/src/main/java/sic/service/PedidoService.java
+++ b/src/main/java/sic/service/PedidoService.java
@@ -24,6 +24,7 @@ public class PedidoService {
 
     private final PedidoRepository pedidoRepository = new PedidoRepository();
     private final EmpresaService empresaService = new EmpresaService();
+    private final FacturaService facturaService = new FacturaService();
 
     private void validarPedido(Pedido pedido) {
         //Entrada de Datos
@@ -84,7 +85,7 @@ public class PedidoService {
     }
 
     public List<Factura> getFacturasDelPedido(long nroPedido) {
-        return pedidoRepository.getFacturasDelPedido(nroPedido);
+        return pedidoRepository.getPedidoPorNumeroConFacturas(nroPedido).getFacturas();
     }
 
     public void guardar(Pedido pedido) {
@@ -160,7 +161,7 @@ public class PedidoService {
         HashMap<Long, RenglonFactura> listaRenglonesUnificados = new HashMap<>();
         if (!facturas.isEmpty()) {
             for (Factura factura : facturas) {
-                renglonesDeFacturas.addAll(factura.getRenglones());
+                renglonesDeFacturas.addAll(facturaService.getRenglonesDeLaFactura(factura));
             }
             for (RenglonFactura renglon : renglonesDeFacturas) {
                 if (listaRenglonesUnificados.containsKey(renglon.getId_ProductoItem())) {


### PR DESCRIPTION
Cuando se da de alta un pedido, con productos cuyas cantidades no están totalmente en stock, y este pedido pasa a facturarse por esas cantidades parciales, la facturación se hace de manera correcta por las cantidades disponibles en stock, el pedido no se cierra, y aún quedan por facturar las cantidades restantes por falta de disponibilidad.