### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/belluccifranco/sic.png?label=ready&title=Ready)](https://waffle.io/belluccifranco/sic?utm_source=badge)
 [![Build Status](https://travis-ci.org/belluccifranco/sic.svg?branch=master)](https://travis-ci.org/belluccifranco/sic)
 
 Board: https://zube.io/belluccifranco/sic/w/workspace/kanban


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/belluccifranco/sic

This was requested by a real person (user belluccifranco) on waffle.io, we're not trying to spam you.